### PR TITLE
Bug fixes

### DIFF
--- a/themes/tilburg/assets/scss/_main.scss
+++ b/themes/tilburg/assets/scss/_main.scss
@@ -67,7 +67,7 @@ pre {
       font-size: 16px;
       font-family: "forma-djr-display", sans-serif;
       line-height: 24px;
-      margin-bottom: 30px;
+      margin-bottom: 10px;
       a {
         color: #003365;
       }
@@ -86,16 +86,16 @@ pre {
   }
   h5 {
     a {
-    color: $secondary !important;
+    color: $secondary;
     &:hover {
-      color: $primary !important;
+      color: $primary;
     }
   }
   }
   a {
-    color: $secondary !important;
+    color: $secondary;
     &:hover {
-      color: $primary !important;
+      color: $primary;
     }
   }
 }
@@ -541,7 +541,9 @@ footer {
   .footerCollapse {
   }
 }
-
+.text-primary {
+  color: $primary !important;
+}
 p {
   font-size: 18px;
   line-height: 26px;

--- a/themes/tilburg/layouts/partials/footer.html
+++ b/themes/tilburg/layouts/partials/footer.html
@@ -30,7 +30,9 @@
 						{{- range where .Site.Pages "Section" "tutorials" -}}
 						{{ if eq .Params.isParent true }}
 						{{- range $index, $value := .Pages -}}
+						{{ if ne .Params.indexexclude true }}
 						<a href="{{ .Permalink }}">{{ .Title }}</a>
+						{{ end }}
 						{{- end -}}
 						{{ end }}
 						{{- end -}}

--- a/themes/tilburg/layouts/partials/footer.html
+++ b/themes/tilburg/layouts/partials/footer.html
@@ -30,7 +30,7 @@
 						{{- range where .Site.Pages "Section" "tutorials" -}}
 						{{ if eq .Params.isParent true }}
 						{{- range $index, $value := .Pages -}}
-						{{ if ne .Params.indexexclude true }}
+						{{ if ne .Params.indexexclude "true" }}
 						<a href="{{ .Permalink }}">{{ .Title }}</a>
 						{{ end }}
 						{{- end -}}

--- a/themes/tilburg/layouts/partials/header.html
+++ b/themes/tilburg/layouts/partials/header.html
@@ -132,7 +132,7 @@
 									<!-- <h5 class="text-secondary" style="font-size: 16px;">{{.Title}}</h5> -->
 
 									{{- range .Pages -}}
-									<a class="h5 d-block mx-0 mb-2 m-0 heading text-secondary" style="color: #003365!important;" href="{{.Permalink}}">{{.Title}}</a>
+									<a class=" d-block mb-3 text-secondary heading" style="color: #003365!important; font-family: forma-djr-display,sans-serif;" href="{{.Permalink}}">{{.Title}}</a>
 									{{ end }}
 								</div>
 

--- a/themes/tilburg/layouts/tutorials/single.html
+++ b/themes/tilburg/layouts/tutorials/single.html
@@ -7,8 +7,11 @@
 	<div class="row justify-content-center">
 		<div class="col-lg-8 col-22">
 			<div class="sticky-top">
+				{{ if .Params.tutorialTitle }} 
+				<h1 class="text-center text-lg-left" style="font-size: 38px; line-height: 48px;">{{ .Params.tutorialTitle }}</h1>
+				{{ else }}
 				<h1 class="text-center text-lg-left" style="font-size: 38px; line-height: 48px;">{{ .Title }}</h1>
-
+				{{ end }}
 				<div class="TableOfContents">
 					<span class="arrow-icon"></span>
 					<div class="pseudo-btn d-block d-lg-none"></div>
@@ -16,7 +19,7 @@
 					{{ with .CurrentSection }}
 					{{ range .Pages }}
 						{{ if eq .Title $currentTitle }}
-						<h5 class="text-secondary heading" style="font-size: 18px; margin-left: 10px; font-weight: 100 !important;"><a href="{{ .Permalink }}">{{ .Title }}</a></h5>
+						<h5 class="text-secondary heading text-primary" style="font-size: 18px; margin-left: 10px; font-weight: 100 !important;"><a href="{{ .Permalink }}">{{ .Title }}</a></h5>
 							
 								{{ .TableOfContents }}
 							

--- a/themes/tilburg/layouts/tutorials/single.html
+++ b/themes/tilburg/layouts/tutorials/single.html
@@ -19,12 +19,13 @@
 					{{ with .CurrentSection }}
 					{{ range .Pages }}
 						{{ if eq .Title $currentTitle }}
-						<h5 class="text-secondary heading text-primary" style="font-size: 18px; margin-left: 10px; font-weight: 100 !important;"><a href="{{ .Permalink }}">{{ .Title }}</a></h5>
+						<h5 class="heading text-primary" style="font-size: 18px; height: 28px; margin-left: 10px; font-weight: 100 !important;"><a class="text-primary" href="{{ .Permalink }}">{{ .Title }}</a></h5>
 							
-								{{ .TableOfContents }}
+							<div class="pl-4">{{ .TableOfContents }}</div>
+								
 							
 						{{ else }}
-						<h5 class="text-secondary heading" style="font-size: 18px; margin-left: 10px; font-weight: 100 !important;"><a href="{{ .Permalink }}">{{ .Title }}</a></h5>
+						<h5 class="text-secondary heading" style="font-size: 18px; height: 38px; margin-left: 10px; font-weight: 100 !important;"><a href="{{ .Permalink }}">{{ .Title }}</a></h5>
 						{{ end }}
 					{{ end }}
 				{{ end }}


### PR DESCRIPTION
- In Tutorials, the big title on the left should be the Tutorial title, not the current MD file title.
- The current MD file title can be simply highlighted in orange in the left-menu navigation because it's the "selected" one
- Exclude from the footer all articles with indexexclude: true
- Reduce vertical margins between left-menu items (check on InVision for the precise height)
- Add a new second level of indentation for the left menu
